### PR TITLE
Allow WTHEADERS to have empty Header Block Fragment

### DIFF
--- a/draft-kinnear-webtransport-http2.md
+++ b/draft-kinnear-webtransport-http2.md
@@ -226,6 +226,10 @@ be sent on a stream in the "idle", "open", or "half-closed (remote)" state, see
 Like HEADERS, the CONTINUATION frame (type=0x9) is used to continue a sequence
 of header block fragments, if the headers do not fit into one WTHEADERS frame.
 
+Unlike HEADERS, the Header Block Fragment field MAY be empty.  There
+are no predefined semantics of the fields in the decoded block.  The
+application uses it to convey arbitrary structured metadata.
+
 The WTHEADERS frame is shown in {{fig-wtheaders}}.
 
 ~~~


### PR DESCRIPTION
If the application doesn't wish to use HTTP/2 to convey structured metadata and take advantage of HPACK compression, it doesn't have to.  Note that in the simplest case then, a WTHEADERS frame is:

```
 0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+-----------------------------------------------+
|                 Length (24)                   |
+---------------+---------------+---------------+
|   Type (8)    |   Flags (8)   |
+-+-------------+---------------+-------------------------------+
|R|                 Stream Identifier (31)                      |
+-+-------------+-----------------------------------------------+
|R|                 Connect Stream ID (31)                      |
+-+-------------+-----------------------------------------------+
```